### PR TITLE
Fix: always set content $groupsWithMembers

### DIFF
--- a/HelloID/Get-HelloIDPersonGroupMembers.ps1
+++ b/HelloID/Get-HelloIDPersonGroupMembers.ps1
@@ -159,9 +159,9 @@ function Get-HelloIDGroupsWithMembers {
                     [void]$groupsResolved.Add($groupResolved)
                 }
                 $groupAugmented.groupsResolved = $groupsResolved
-
-                [void]$groupsWithMembers.Value.Add($groupAugmented)
             }
+
+            [void]$groupsWithMembers.Value.Add($groupAugmented)
         }
     }
     catch {


### PR DESCRIPTION
Fixed to always set content $groupsWithMembers (also when not including nestin)